### PR TITLE
[Fixes #10] Hide 'complete' action button in notification in case of break sessions

### DIFF
--- a/app/src/main/java/gis2018/udacity/pomodoro/MainActivity.java
+++ b/app/src/main/java/gis2018/udacity/pomodoro/MainActivity.java
@@ -293,7 +293,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         Intent serviceIntent = new Intent(this, CountDownTimerService.class);
         serviceIntent.putExtra("time_period", duration);
         serviceIntent.putExtra("time_interval", TIME_INTERVAL);
-        serviceIntent.putExtra("service_type", currentlyRunningServiceType);
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
             startForegroundService(serviceIntent);
         else

--- a/app/src/main/java/gis2018/udacity/pomodoro/MainActivity.java
+++ b/app/src/main/java/gis2018/udacity/pomodoro/MainActivity.java
@@ -293,6 +293,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         Intent serviceIntent = new Intent(this, CountDownTimerService.class);
         serviceIntent.putExtra("time_period", duration);
         serviceIntent.putExtra("time_interval", TIME_INTERVAL);
+        serviceIntent.putExtra("service_type", currentlyRunningServiceType);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
             startForegroundService(serviceIntent);
         else


### PR DESCRIPTION
## Description

As per the changes made, the notification displays both `Complete` and `Cancel` action buttons when a *pomodoro* is running and only the `Cancel` button when a *break* session is running.

Fixes #10 and Fixes #7 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

![pomodoro_notification_action](https://user-images.githubusercontent.com/5392993/49600696-d13c9d80-f9a9-11e8-9635-1a82f1b2f958.jpg)  ![break_notification_action](https://user-images.githubusercontent.com/5392993/49600695-d0a40700-f9a9-11e8-9033-ba2077eebd31.jpg)

I was wondering if we also need to set different notification title and content for pomodoro and break sessions. Please let me know in case of any changes.