### PR TITLE
Display countdown time in the notification.

### DIFF
--- a/app/src/main/java/gis2018/udacity/tametu/CountDownTimerService.java
+++ b/app/src/main/java/gis2018/udacity/tametu/CountDownTimerService.java
@@ -5,10 +5,10 @@ import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.CountDownTimer;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
-import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.content.LocalBroadcastManager;
 
@@ -50,7 +50,6 @@ public class CountDownTimerService extends Service {
 
     @Override
     public IBinder onBind(Intent intent) {
-        // TODO: Return the communication channel to the service.
         throw new UnsupportedOperationException("Not yet implemented");
     }
 
@@ -76,12 +75,32 @@ public class CountDownTimerService extends Service {
         PendingIntent cancelActionPendingIntent = PendingIntent.getBroadcast(this,
                 0, cancelIntent, 0);
 
+        Notification.Builder notificationBuilder = null;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            notificationBuilder = new Notification.Builder(this, CHANNEL_ID);
 
-        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, CHANNEL_ID)
+        } else {
+            notificationBuilder = new Notification.Builder(this);
+        }
+
+        notificationBuilder = notificationBuilder
                 .setSmallIcon(R.drawable.ic_notification_icon)
-                .setColor(getResources().getColor(R.color.colorPrimary))
                 .setContentIntent(pendingIntent)
                 .setOngoing(false);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            notificationBuilder = notificationBuilder
+                    .setWhen(System.currentTimeMillis() + TIME_PERIOD)
+                    .setUsesChronometer(true)
+                    .setChronometerCountDown(true);
+        }
+
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            notificationBuilder = notificationBuilder
+                    .setColor(getResources().getColor(R.color.colorPrimary));
+
+        }
 
         //adding separate cases for both service types to ensure the order of the action
         //buttons is preserved in the notification

--- a/app/src/main/java/gis2018/udacity/tametu/MainActivity.java
+++ b/app/src/main/java/gis2018/udacity/tametu/MainActivity.java
@@ -496,7 +496,8 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 .setSmallIcon(R.drawable.ic_notification_icon)
                 .setContentIntent(pendingIntent)
                 .setAutoCancel(true)
-                .setColor(getResources().getColor(R.color.colorPrimary));
+                .setColor(getResources().getColor(R.color.colorPrimary))
+                .setUsesChronometer(true); //timer that counts-up. Displays time in-between two sessions
 
         switch (currentlyRunningServiceType) {
             case TAMETU:


### PR DESCRIPTION
Countdown time now updates in the notification.

Also, an additional feature: Time elapsed since the _end_ of the timer is also displayed - in short it shows  _time wasted_.
![device-2018-12-29-193020](https://user-images.githubusercontent.com/28054527/50539112-aa384c80-0ba0-11e9-959d-23fcf91b64a8.png)

Fixes #1 

## Type of change
Just put an x in the [] which are valid.
- [x] New feature (non-breaking change which adds functionality)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
